### PR TITLE
Pass aligned ptrs to SPI::transferBytes. 

### DIFF
--- a/ProDinoWiFiEsp/src/PRODINoESP8266/src/KMPDinoWiFiESP.cpp
+++ b/ProDinoWiFiEsp/src/PRODINoESP8266/src/KMPDinoWiFiESP.cpp
@@ -57,8 +57,8 @@ const uint8_t RELAY_PINS[RELAY_COUNT] =
 const int OPTOIN_PINS[OPTOIN_COUNT] =
 { IN1PIN, IN2PIN, IN3PIN, IN4PIN };
 
-uint8_t  _expTxData[16];
-uint8_t  _expRxData[16];
+uint8_t  _expTxData[16]  __attribute__((aligned(4)));
+uint8_t  _expRxData[16]  __attribute__((aligned(4)));
 
 KMPDinoWiFiESPClass KMPDinoWiFiESP;
 


### PR DESCRIPTION
This should solve exception(9) on SPI communication when compiling code on non-windows machines