### PR TITLE
Use the Ethernet library instead of Ethernet2

### DIFF
--- a/ProDinoMKRZero/src/ProDinoMKRZero/examples/BlynkOne/BlynkOne.ino
+++ b/ProDinoMKRZero/src/ProDinoMKRZero/examples/BlynkOne/BlynkOne.ino
@@ -38,7 +38,7 @@
 #define DEBUG
 //#define BLYNK_DEBUG
 //#define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
-#include <BlynkSimpleEthernet2.h>
+#include <BlynkSimpleEthernet.h>
 
 // You have to get your Authentication Token through Blynk Application.
 char AUTH_TOKEN[] = "123456789012345678901234567890123";

--- a/ProDinoMKRZero/src/ProDinoMKRZero/src/KMPCommon.h
+++ b/ProDinoMKRZero/src/ProDinoMKRZero/src/KMPCommon.h
@@ -12,7 +12,7 @@
 
 #include "Arduino.h"
 #include "IPAddress.h"
-#include <Ethernet2.h>
+#include <Ethernet.h>
 
 #ifndef UINT8_MAX
 #define UINT8_MAX (~(uint8_t)0)

--- a/ProDinoMKRZero/src/ProDinoMKRZero/src/KMPProDinoMKRZero.h
+++ b/ProDinoMKRZero/src/ProDinoMKRZero/src/KMPProDinoMKRZero.h
@@ -16,7 +16,7 @@
 #define _KMPPRODINOMKRZERO_H
 
 #include <Arduino.h>
-#include <Ethernet2.h>
+#include <Ethernet.h>
 #include <HardwareSerial.h>
 
 // Inputs and outputs count.


### PR DESCRIPTION
As per https://github.com/adafruit/Ethernet2/pull/20, the Ethernet
library now supports W5500 shields. Move to this, as Ethernet2 is
going to be deprecated in the future.

The library part of it has been tested and works with my project, the BlynkOne example has only been compile-tested though.

I only touched the ProDinoMKRZero library, as I only have access to the MKR GSM Ethernet board, it may be a good idea to look in the other libraries too. I can also patch the other libraries if you're inclined to test them.

Cheers!