### PR TITLE
Include Arduino.h instead of arduino.h

### DIFF
--- a/ProDinoMKRZero/src/ProDinoMKRZero/src/MqttTopicHelper.h
+++ b/ProDinoMKRZero/src/ProDinoMKRZero/src/MqttTopicHelper.h
@@ -4,7 +4,7 @@
 #define _MQTTTOPICHELPER_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-#include "arduino.h"
+#include "Arduino.h"
 #else
 #include "WProgram.h"
 #endif


### PR DESCRIPTION
This makes Unix-like (case-sensitive) systems happy.